### PR TITLE
flakefy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,42 +16,18 @@ git clone https://github.com/smravec/nixos-config
 ```
 ### Nixos
 Go to ``nixos/networking/networks.nix`` and setup wifi (in the cloned repository) <br/>
-Copy ``/etc/nixos/hardware-configuration.nix`` to ``nixos/hardware-optimization``
-```
-cp /etc/nixos/hardware-configuration.nix ~/nixos-config/nixos/hardware-optimization/
-```
-Symlink this repository to ``/etc`` <br/>
-```
-cd /etc
-```
-```
-sudo rm -rf nixos
-```
-```
-sudo ln -s ~/nixos-config/nixos/ .
-```
+
 Rebuild your system
 ```
-sudo nixos-rebuild switch
+sudo nixos-rebuild switch --flake .
 ```
 ### Home manager
-Download home-manager standalone ( after adding the home-manager channel reboot to refresh the $NIX_PATH var ) <br/>
-https://nix-community.github.io/home-manager/index.html#sec-install-standalone <br/>
-Symlink ``home-manager`` directory to ``~/.config`` <br/>
+Get home-manager:
 ```
-cd ~/.config
+nix shell nixpkgs#home-manager
 ```
 ```
-rm -rf nixpkgs
-```
-```
-ln -s ~/nixos-config/home-manager/ nixpkgs
-```
-Add unstable channel <br/>
-https://nix-community.github.io/home-manager/index.html#_how_do_i_install_packages_from_nixpkgs_unstable <br/>
-Rebuild home-manager
-```
-home-manager switch
+home-manager switch --flake .
 ```
 ### Sway
 Symlink sway config <br/>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1676892629,
+        "narHash": "sha256-rlvsqoSBO5dCwfnn7xvImYREidIPJaiFS3b54TZF4pU=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "72ce74d3eae78a6b31538ea7ebe0c1fcf4a10f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1676817468,
+        "narHash": "sha256-ovuJ1jQOC2/EEibufBkXmSN/O9mLx80Wh7aDmHmHAhA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0cf4274b5d06325bd16dbf879a30981bc283e58a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1680669251,
+        "narHash": "sha256-AVNE+0u4HlI3v96KCXE9risH7NKqj0QDLLfSckYXIbA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9c8ff8b426a8b07b9e0a131ac3218740dc85ba1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "Your new nix config";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { nixpkgs, home-manager, ... }@inputs: {
+    # NixOS configuration entrypoint
+    # Available through 'nixos-rebuild --flake .'
+    nixosConfigurations = {
+      "framework" = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        specialArgs = { inherit inputs; };
+        modules = [ ./nixos/configuration.nix ];
+      };
+    };
+
+    # Standalone home-manager configuration entrypoint
+    # Available through 'home-manager --flake .'
+    homeConfigurations = {
+      "simon@framework" = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages."x86_64-linux";
+        extraSpecialArgs = { inherit inputs; };
+        modules = [ ./home-manager/home.nix ];
+      };
+    };
+  };
+}

--- a/home-manager/config/yt-dlp.nix
+++ b/home-manager/config/yt-dlp.nix
@@ -1,8 +1,10 @@
-{ pkgs, config, ... }:
+{ pkgs, config, inputs, ... }:
 
 let
 
-  pkgsUnstable = import <nixpkgs-unstable> {};
+  pkgsUnstable = import inputs.nixpkgs-unstable {
+    system = pkgs.system;
+  };
 
 in
 

--- a/nixos/hardware-optimization/hardware-configuration.nix
+++ b/nixos/hardware-optimization/hardware-configuration.nix
@@ -1,0 +1,9 @@
+# TODO: you should commit your hardware-configuration.nix
+# This is just a sample so that the config builds
+{
+  fileSystems."/" = {
+    device = "none";
+    fsType = "tmpfs";
+    options = [ "defaults" "size=2G" "mode=755" ];
+  };
+}

--- a/nixos/silent-boot/etc-silent.nix
+++ b/nixos/silent-boot/etc-silent.nix
@@ -1,6 +1,6 @@
 # Management of static files in /etc.
 
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, inputs, ... }:
 
 with lib;
 
@@ -66,7 +66,9 @@ in
 
 {
 
-  imports = [ /nix/var/nix/profiles/per-user/root/channels/nixos/nixos/modules/system/build.nix ];
+  imports = [
+    "${inputs.nixpkgs}/nixos/modules/system/build.nix"
+  ];
 
   ###### interface
 
@@ -194,7 +196,7 @@ in
       ''
         # Set up the statically computed bits of /etc.
         #echo "setting up /etc..."
-        ${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl ${/nix/var/nix/profiles/per-user/root/channels/nixos/nixos/modules/system/etc/setup-etc.pl} ${etc}/etc
+        ${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl ${inputs.nixpkgs}/nixos/modules/system/etc/setup-etc.pl ${etc}/etc
       '';
   };
 


### PR DESCRIPTION
This commit adds a flake.nix to the repo, adjusts the config to use inputs instead of channels, and updates the readme accordingly.

You should commit your hardware configuration file.

And also consider using sway through home-manager, you can easily make it put your configuration in the righr place. In general, systemwide configs are only needed for DMs (therefore DEs), but not standalone WMs, so they have much better modules in home-manager instead.
